### PR TITLE
MRSAL-2 Add properties and deliver to consumer_callback parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ poetry.lock
 this_dockerfile_with_certs_path
 docker-compose.override.yml
 .env
+rabbitmq_vol/
+credentials/rabbit_certs/
+storage/model_conf/mrsal_conf/mrsal.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,12 @@ services:
       - "${RABBITMQ_PORT}:5672"
       # OPTIONAL: Expose the GUI port
       - "${RABBITMQ_GUI_PORT}:15672"
+    networks:
+      - gateway
+
+# Make the externally created network "gateway" available as network "default" 
+# If "gateway" not exists then create it with
+# docker network create --internal=false --attachable --driver=bridge gateway
+networks:
+  gateway:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,6 @@ services:
     ports:
       # RabbitMQ container listening on the default port of 5672.
       # Expose default port to the port 5673
-      - "${RABBITMQ_CONTAINER_PORT}:5672"
+      - "${RABBITMQ_PORT}:5672"
       # OPTIONAL: Expose the GUI port
       - "${RABBITMQ_GUI_PORT}:15672"

--- a/mrsal/mrsal.py
+++ b/mrsal/mrsal.py
@@ -313,7 +313,7 @@ class Mrsal:
                              requeue the message. If requeue is false or the
                              requeue attempt fails the messages are discarded or
                              dead-lettered.
-        :param bool callback_with_delivery_info: Specify whether the callback method need delivery info.
+        :param bool callback_with_delivery_info: Specify whether the callback method needs delivery info.
                 - spec.Basic.Deliver: Captures the fields for delivered message. E.g:(consumer_tag, delivery_tag, redelivered, exchange, routing_key).
                 - spec.BasicProperties: Captures the client message sent to the server. E.g:(CONTENT_TYPE, DELIVERY_MODE, MESSAGE_ID, APP_ID). 
         """

--- a/mrsal/mrsal.py
+++ b/mrsal/mrsal.py
@@ -345,7 +345,7 @@ class Mrsal:
                                 delivery_tag= {method_frame.delivery_tag},
                                 properties= {properties},
                                 consumer_tags= {consumer_tags},
-                                consumer_tag= {consumer_tag}
+                                consumer_tag= {self.consumer_tag}
                                 """)
                         is_processed = callback(*callback_args, method_frame, properties, body) if callback_args else callback(method_frame, properties, body)
                         if is_processed:

--- a/tests/test_delay_and_dl_messages/test_dead_and_delay_letters.py
+++ b/tests/test_delay_and_dl_messages/test_dead_and_delay_letters.py
@@ -148,7 +148,8 @@ def test_delay_and_dead_letters():
         callback=consumer_callback,
         callback_args=(test_config.HOST, 'agreements_queue'),
         inactivity_timeout=6,
-        requeue=False
+        requeue=False,
+        callback_with_delivery_info=True
     )
     # ------------------------------------------
 
@@ -174,7 +175,8 @@ def test_delay_and_dead_letters():
         callback=consumer_dead_letters_callback,
         callback_args=(test_config.HOST, 'dl_agreements_queue'),
         inactivity_timeout=3,
-        requeue=False
+        requeue=False,
+        callback_with_delivery_info=True
     )
     # ------------------------------------------
 

--- a/tests/test_delay_and_dl_messages/test_dead_and_delay_letters.py
+++ b/tests/test_delay_and_dl_messages/test_dead_and_delay_letters.py
@@ -71,31 +71,55 @@ def test_delay_and_dead_letters():
     """
     x_delay1: int = 2000  # ms
     message1 = 'uuid1'
+    prop1 = pika.BasicProperties(
+        app_id='test_exchange_dead_and_delay_letters',
+        message_id='uuid1_2000ms',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'x-delay': x_delay1})
     mrsal.publish_message(exchange='agreements',
                           routing_key='agreements_key',
-                          message=json.dumps(message1),
-                          headers={'x-delay': x_delay1})
+                          message=json.dumps(message1), prop=prop1)
 
     x_delay2: int = 1000
     message2 = 'uuid2'
+    prop2 = pika.BasicProperties(
+        app_id='test_exchange_dead_and_delay_letters',
+        message_id='uuid2_1000ms',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'x-delay': x_delay2})
     mrsal.publish_message(exchange='agreements',
                           routing_key='agreements_key',
-                          message=json.dumps(message2),
-                          headers={'x-delay': x_delay2})
+                          message=json.dumps(message2), prop=prop2)
 
     x_delay3: int = 3000
     message3 = 'uuid3'
+    prop3 = pika.BasicProperties(
+        app_id='test_exchange_dead_and_delay_letters',
+        message_id='uuid3_3000ms',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'x-delay': x_delay3})
     mrsal.publish_message(exchange='agreements',
                           routing_key='agreements_key',
-                          message=json.dumps(message3),
-                          headers={'x-delay': x_delay3})
+                          message=json.dumps(message3), prop=prop3)
 
     x_delay4: int = 4000
     message4 = 'uuid4'
+    prop4 = pika.BasicProperties(
+        app_id='test_exchange_dead_and_delay_letters',
+        message_id='uuid4_4000ms',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'x-delay': x_delay4})
     mrsal.publish_message(exchange='agreements',
                           routing_key='agreements_key',
-                          message=json.dumps(message4),
-                          headers={'x-delay': x_delay4})
+                          message=json.dumps(message4), prop=prop4)
     # ------------------------------------------
 
     log.info('===== Start consuming from "agreements_queue" ========')
@@ -160,12 +184,12 @@ def test_delay_and_dead_letters():
     log.info(f'Message count in queue "dl_agreements_queue" after consuming= {message_count}')
     assert message_count == 0
 
-def consumer_callback(host: str, queue: str, message: str):
+def consumer_callback(host: str, queue: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message: str):
     if message == b'"\\"uuid3\\""':
         time.sleep(3)
     return message != b'"\\"uuid2\\""'
 
-def consumer_dead_letters_callback(host_param: str, queue_param: str, message_param: str):
+def consumer_dead_letters_callback(host_param: str, queue_param: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties,message_param: str):
     return True
 
 

--- a/tests/test_delay_and_dl_messages/test_dead_letters.py
+++ b/tests/test_delay_and_dl_messages/test_dead_letters.py
@@ -12,7 +12,8 @@ log = get_logger(__name__)
 mrsal = Mrsal(host=test_config.HOST,
              port=config.RABBITMQ_PORT,
              credentials=config.RABBITMQ_CREDENTIALS,
-             virtual_host=config.V_HOST)
+             virtual_host=config.V_HOST,
+             verbose=True)
 mrsal.connect_to_server()
 
 def test_dead_letters():

--- a/tests/test_delay_and_dl_messages/test_dead_letters.py
+++ b/tests/test_delay_and_dl_messages/test_dead_letters.py
@@ -67,24 +67,52 @@ def test_dead_letters():
       Message ("uuid4") is published
     """
     message1 = 'uuid1'
+    prop1 = pika.BasicProperties(
+        app_id='test_exchange_dead_letters',
+        message_id='msg_uuid1',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
     mrsal.publish_message(exchange='agreements',
                          routing_key='agreements_key',
-                         message=json.dumps(message1))
+                         message=json.dumps(message1), prop=prop1)
 
     message2 = 'uuid2'
+    prop2 = pika.BasicProperties(
+        app_id='test_exchange_dead_letters',
+        message_id='msg_uuid2',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
     mrsal.publish_message(exchange='agreements',
                          routing_key='agreements_key',
-                         message=json.dumps(message2))
+                         message=json.dumps(message2), prop=prop2)
 
     message3 = 'uuid3'
+    prop3 = pika.BasicProperties(
+        app_id='test_exchange_dead_letters',
+        message_id='msg_uuid3',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
     mrsal.publish_message(exchange='agreements',
                          routing_key='agreements_key',
-                         message=json.dumps(message3))
+                         message=json.dumps(message3), prop=prop3)
 
     message4 = 'uuid4'
+    prop4 = pika.BasicProperties(
+        app_id='test_exchange_dead_letters',
+        message_id='msg_uuid4',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
     mrsal.publish_message(exchange='agreements',
                          routing_key='agreements_key',
-                         message=json.dumps(message4))
+                         message=json.dumps(message4), prop=prop4)
     # ------------------------------------------
 
     log.info(f'===== Start consuming from "agreements_queue" ========')
@@ -147,12 +175,12 @@ def test_dead_letters():
     log.info(f'Message count in queue "dl_agreements_queue" after consuming= {message_count}')
     assert message_count == 0
 
-def consumer_callback(host: str, queue: str, message: str):
+def consumer_callback(host: str, queue: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message: str):
     if message == b'"\\"uuid3\\""':
         time.sleep(3)
     return message != b'"\\"uuid2\\""'
 
-def consumer_dead_letters_callback(host_param: str, queue_param: str, message_param: str):
+def consumer_dead_letters_callback(host_param: str, queue_param: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str):
     return True
 
 

--- a/tests/test_delay_and_dl_messages/test_dead_letters.py
+++ b/tests/test_delay_and_dl_messages/test_dead_letters.py
@@ -141,7 +141,8 @@ def test_dead_letters():
         callback=consumer_callback,
         callback_args=(test_config.HOST, 'agreements_queue'),
         inactivity_timeout=6,
-        requeue=False
+        requeue=False,
+        callback_with_delivery_info=True
     )
     # ------------------------------------------
 
@@ -166,7 +167,8 @@ def test_dead_letters():
         callback=consumer_dead_letters_callback,
         callback_args=(test_config.HOST, 'dl_agreements_queue'),
         inactivity_timeout=3,
-        requeue=False
+        requeue=False,
+        callback_with_delivery_info=True
     )
     # ------------------------------------------
 

--- a/tests/test_delay_and_dl_messages/test_delay_letters.py
+++ b/tests/test_delay_and_dl_messages/test_delay_letters.py
@@ -46,17 +46,29 @@ def test_delay_letter():
     """
     x_delay1: int = 3000
     message1 = 'uuid1'
+    prop1 = pika.BasicProperties(
+        app_id='test_exchange_delay_letters',
+        message_id='uuid1_3000ms',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'x-delay': x_delay1})
     mrsal.publish_message(exchange='agreements',
                           routing_key='agreements_key',
-                          message=json.dumps(message1),
-                          headers={'x-delay': x_delay1})
+                          message=json.dumps(message1), prop=prop1)
 
     x_delay2: int = 1000
     message2 = 'uuid2'
+    prop2 = pika.BasicProperties(
+        app_id='test_exchange_delay_letters',
+        message_id='uuid2_1000ms',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'x-delay': x_delay2})
     mrsal.publish_message(exchange='agreements',
                           routing_key='agreements_key',
-                          message=json.dumps(message2),
-                          headers={'x-delay': x_delay2})
+                          message=json.dumps(message2), prop=prop2)
     # ------------------------------------------
 
     log.info('===== Start consuming from "agreements_queue" ========')

--- a/tests/test_delay_and_dl_messages/test_exceptions.py
+++ b/tests/test_delay_and_dl_messages/test_exceptions.py
@@ -119,6 +119,6 @@ def test_bind_exceptions():
 
 
 if __name__ == '__main__':
-    # test_connection_exceptions()
+    test_connection_exceptions()
     test_exchange_exceptions()
-    # test_bind_exceptions()
+    test_bind_exceptions()

--- a/tests/test_delay_and_dl_messages/test_exceptions.py
+++ b/tests/test_delay_and_dl_messages/test_exceptions.py
@@ -119,6 +119,6 @@ def test_bind_exceptions():
 
 
 if __name__ == '__main__':
-    test_connection_exceptions()
+    # test_connection_exceptions()
     test_exchange_exceptions()
-    test_bind_exceptions()
+    # test_bind_exceptions()

--- a/tests/test_exchange_types/test_exchange_direct_workflow.py
+++ b/tests/test_exchange_types/test_exchange_direct_workflow.py
@@ -94,10 +94,11 @@ def test_direct_exchange_workflow():
     # Start consumer for every queue
     mrsal.start_consumer(
         queue='agreements_berlin_queue',
-        callback=consumer_callback,
+        callback=consumer_callback_with_delivery_info,
         callback_args=(test_config.HOST, 'agreements_berlin_queue'),
         inactivity_timeout=1,
-        requeue=False
+        requeue=False,
+        callback_with_delivery_info=True
     )
 
     mrsal.start_consumer(
@@ -105,7 +106,7 @@ def test_direct_exchange_workflow():
         callback=consumer_callback,
         callback_args=(test_config.HOST, 'agreements_madrid_queue'),
         inactivity_timeout=1,
-        requeue=False
+        requeue=False,
     )
     # ------------------------------------------
 
@@ -118,9 +119,11 @@ def test_direct_exchange_workflow():
     message_count2 = result2.method.message_count
     assert message_count2 == 0
 
-def consumer_callback(host_param: str, queue_param: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str):
+def consumer_callback_with_delivery_info(host_param: str, queue_param: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str):
     return True
 
+def consumer_callback(host_param: str, queue_param: str, message_param: str):
+    return True
 
 if __name__ == '__main__':
     test_direct_exchange_workflow()

--- a/tests/test_exchange_types/test_exchange_direct_workflow.py
+++ b/tests/test_exchange_types/test_exchange_direct_workflow.py
@@ -52,22 +52,32 @@ def test_direct_exchange_workflow():
     # ------------------------------------------
 
     # Publisher:
-    prop = pika.BasicProperties(
+    prop1 = pika.BasicProperties(
+        app_id='test_exchange_direct',
+        message_id='madrid_uuid',
         content_type=test_config.CONTENT_TYPE,
         content_encoding=test_config.CONTENT_ENCODING,
-        delivery_mode=pika.DeliveryMode.Persistent)
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
 
     # Message ("uuid2") is published to the exchange and it's routed to queue2
     message2 = 'uuid2'
     mrsal.publish_message(exchange='agreements',
                          routing_key='madrid agreements',
-                         message=json.dumps(message2))
+                         message=json.dumps(message2), prop=prop1)
 
+    prop2 = pika.BasicProperties(
+        app_id='test_exchange_direct',
+        message_id='berlin_uuid',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
     # Message ("uuid1") is published to the exchange and it's routed to queue1
     message1 = 'uuid1'
     mrsal.publish_message(exchange='agreements',
                          routing_key='berlin agreements',
-                         message=json.dumps(message1))
+                         message=json.dumps(message1), prop=prop2)
     # ------------------------------------------
 
     time.sleep(1)
@@ -108,7 +118,7 @@ def test_direct_exchange_workflow():
     message_count2 = result2.method.message_count
     assert message_count2 == 0
 
-def consumer_callback(host_param: str, queue_param: str, message_param: str):
+def consumer_callback(host_param: str, queue_param: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str):
     return True
 
 

--- a/tests/test_exchange_types/test_exchange_headers_workflow.py
+++ b/tests/test_exchange_types/test_exchange_headers_workflow.py
@@ -98,7 +98,8 @@ def test_headers_exchange_workflow():
         callback=consumer_callback,
         callback_args=(test_config.HOST, 'zip_report'),
         inactivity_timeout=2,
-        requeue=False
+        requeue=False,
+        callback_with_delivery_info=True
     )
 
     mrsal.start_consumer(
@@ -106,7 +107,8 @@ def test_headers_exchange_workflow():
         callback=consumer_callback,
         callback_args=(test_config.HOST, 'pdf_report'),
         inactivity_timeout=2,
-        requeue=False
+        requeue=False,
+        callback_with_delivery_info=True
     )
     # ------------------------------------------
 

--- a/tests/test_exchange_types/test_exchange_headers_workflow.py
+++ b/tests/test_exchange_types/test_exchange_headers_workflow.py
@@ -53,20 +53,32 @@ def test_headers_exchange_workflow():
 
     # Publisher:
     # Message ("uuid1") is published to the exchange with a set of headers
+    prop1 = pika.BasicProperties(
+        app_id='test_exchange_headers',
+        message_id='zip_report',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'format': 'zip', 'type': 'report'})
 
     message1 = 'uuid1'
     mrsal.publish_message(exchange='agreements',
                           routing_key='',
-                          message=json.dumps(message1),
-                          headers={'format': 'zip', 'type': 'report'})
+                          message=json.dumps(message1), prop=prop1
+                          )
 
     # Message ("uuid2") is published to the exchange with a set of headers
-
+    prop2 = pika.BasicProperties(
+        app_id='test_exchange_headers',
+        message_id='pdf_date',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'format': 'pdf', 'date': '2022'})
     message2 = 'uuid2'
     mrsal.publish_message(exchange='agreements',
                           routing_key='',
-                          message=json.dumps(message2),
-                          headers={'format': 'pdf', 'date': '2022'})
+                          message=json.dumps(message2), prop=prop2)
     # ------------------------------------------
 
     time.sleep(1)
@@ -108,7 +120,7 @@ def test_headers_exchange_workflow():
     assert message_count2 == 0
 
 
-def consumer_callback(host_param: str, queue_param: str, message_param: str):
+def consumer_callback(host_param: str, queue_param: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str):
     return True
 
 

--- a/tests/test_exchange_types/test_exchange_topic_workflow.py
+++ b/tests/test_exchange_types/test_exchange_topic_workflow.py
@@ -104,7 +104,8 @@ def test_topic_exchange_workflow():
         callback=consumer_callback,
         callback_args=(test_config.HOST, 'berlin_agreements'),
         inactivity_timeout=1,
-        requeue=False
+        requeue=False,
+        callback_with_delivery_info=True
     )
 
     mrsal.start_consumer(
@@ -112,7 +113,8 @@ def test_topic_exchange_workflow():
         callback=consumer_callback,
         callback_args=(test_config.HOST, 'september_agreements'),
         inactivity_timeout=1,
-        requeue=False
+        requeue=False,
+        callback_with_delivery_info=True
     )
     # ------------------------------------------
 

--- a/tests/test_exchange_types/test_exchange_topic_workflow.py
+++ b/tests/test_exchange_types/test_exchange_topic_workflow.py
@@ -62,15 +62,29 @@ def test_topic_exchange_workflow():
 
     # Message ("uuid1") is published to the exchange will be routed to queue1
     message1 = 'uuid1'
+    prop1 = pika.BasicProperties(
+        app_id='test_exchange_topic',
+        message_id='berlin',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
     mrsal.publish_message(exchange='agreements',
                          routing_key=ROUTING_KEY_1,
-                         message=json.dumps(message1))
+                         message=json.dumps(message1), prop=prop1)
 
     # Message ("uuid2") is published to the exchange will be routed to queue2
     message2 = 'uuid2'
+    prop2 = pika.BasicProperties(
+        app_id='test_exchange_topic',
+        message_id='september',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
     mrsal.publish_message(exchange='agreements',
                          routing_key=ROUTING_KEY_2,
-                         message=json.dumps(message2))
+                         message=json.dumps(message2), prop=prop2)
     # ----------------------------------
 
     time.sleep(1)
@@ -111,7 +125,7 @@ def test_topic_exchange_workflow():
     message_count2 = result2.method.message_count
     assert message_count2 == 0
 
-def consumer_callback(host_param: str, queue_param: str, message_param: str):
+def consumer_callback(host_param: str, queue_param: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str):
     return True
 
 

--- a/tests/test_fast_setup/test_fast_setup.py
+++ b/tests/test_fast_setup/test_fast_setup.py
@@ -9,19 +9,16 @@ from mrsal.mrsal import Mrsal
 
 log = get_logger(__name__)
 
-# mrsal = Mrsal(
-#     # host=test_config.HOST,
-#     host=config.RABBIT_DOMAIN,
-#     port=config.RABBITMQ_PORT_TLS,
-#     ssl=True,
-#     credentials=config.RABBITMQ_CREDENTIALS,
-#     virtual_host=config.V_HOST
-# )
+mrsal = Mrsal(
+    # host=test_config.HOST,
+    host=config.RABBIT_DOMAIN,
+    port=config.RABBITMQ_PORT_TLS,
+    ssl=True,
+    credentials=config.RABBITMQ_CREDENTIALS,
+    virtual_host=config.V_HOST
+)
 
-mrsal = Mrsal(host=test_config.HOST,
-              port=config.RABBITMQ_PORT,
-              credentials=config.RABBITMQ_CREDENTIALS,
-              virtual_host=config.V_HOST)
+
 mrsal.connect_to_server()
 
 def test_fast_setup():
@@ -64,7 +61,8 @@ def test_fast_setup():
         queue='friendship_queue',
         callback=consumer_callback,
         callback_args=('localhost', 'friendship_queue'),
-        inactivity_timeout=1
+        inactivity_timeout=1,
+        callback_with_delivery_info=True
     )
     # ------------------------------------------
 

--- a/tests/test_fast_setup/test_fast_setup.py
+++ b/tests/test_fast_setup/test_fast_setup.py
@@ -1,5 +1,6 @@
 import json
 import time
+import pika
 
 import mrsal.config.config as config
 import tests.config as test_config
@@ -8,15 +9,19 @@ from mrsal.mrsal import Mrsal
 
 log = get_logger(__name__)
 
-mrsal = Mrsal(
-    # host=test_config.HOST,
-    host=config.RABBIT_DOMAIN,
-    port=config.RABBITMQ_PORT_TLS,
-    ssl=True,
-    credentials=config.RABBITMQ_CREDENTIALS,
-    virtual_host=config.V_HOST
-)
+# mrsal = Mrsal(
+#     # host=test_config.HOST,
+#     host=config.RABBIT_DOMAIN,
+#     port=config.RABBITMQ_PORT_TLS,
+#     ssl=True,
+#     credentials=config.RABBITMQ_CREDENTIALS,
+#     virtual_host=config.V_HOST
+# )
 
+mrsal = Mrsal(host=test_config.HOST,
+              port=config.RABBITMQ_PORT,
+              credentials=config.RABBITMQ_CREDENTIALS,
+              virtual_host=config.V_HOST)
 mrsal.connect_to_server()
 
 def test_fast_setup():
@@ -26,13 +31,22 @@ def test_fast_setup():
     mrsal.queue_delete(queue='friendship_queue')
     # ------------------------------------------
 
+    prop = pika.BasicProperties(
+            app_id='test_fast_setup',
+            message_id='fast_setup',
+            content_type=test_config.CONTENT_TYPE,
+            content_encoding=test_config.CONTENT_ENCODING,
+            delivery_mode=pika.DeliveryMode.Persistent,
+            headers=None)
+
     mrsal.publish_message(
         exchange='friendship',
         exchange_type='direct',
         routing_key='friendship_key',
         queue='friendship_queue',
         message=json.dumps('Salaam habibi'),
-        fast_setup=True
+        fast_setup=True,
+        prop=prop
     )
     # ------------------------------------------
 
@@ -60,7 +74,7 @@ def test_fast_setup():
     assert message_count == 0
 
 
-def consumer_callback(host: str, queue: str, bin_message: str):
+def consumer_callback(host: str, queue: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, bin_message: str):
     str_message = json.loads(bin_message).replace('"', '')
     if 'Salaam' in str_message:
         return True  # Consumed message processed correctly


### PR DESCRIPTION
- Add **OPTIONAL** param `callback_with_delivery_info` to **start_consumer** to specify whether the callback method needs delivery info.
     - `spec.Basic.Deliver`: Captures the fields for a delivered message. E.g:(_**consumer_tag, delivery_tag, redelivered, exchange, routing_key**_).
     - `spec.BasicProperties`: Captures the client message sent to the server. E.g:(_**CONTENT_TYPE, DELIVERY_MODE, MESSAGE_ID, APP_ID**_). 
- Refactor `publish_message` and move all publish properties params to one param `pika.BasicProperties`
  - **app_id**    <-- New prop
  - **message_id**   <-- New prop
  - `content_type`
  - `content_encoding`
  - `delivery_mode`
  - `headers`