### PR TITLE
MRSAL-3: Modify max_message_size and reformat doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ mrsal.publish_message(exchange='friendship',
 Now lets setup a consumer that will listen to our very important messages. If you are using scripts rather than notebooks then it's advisable to run consume and publish separately. We are going to need a callback function which is triggered upon receiving the message from the queue we subscribe to. You can use the callback function to activate something in your system.
 
 Note: 
-- If you start a consumer with `callback_with_delivery_info=True` then your callback function should to have at least these params `(method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str)`. 
+- If you start a consumer with `callback_with_delivery_info=True` then your callback function should have at least these params `(method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str)`. 
 - If not, then it should have at least `(message_param: str)`
 
 ```python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - RABBITMQ_DEFAULT_VHOST=${RABBITMQ_DEFAULT_VHOST}
     ports:
       # RabbitMQ container listening on the default port of 5672.
-      # Expose default port to the port 5673
       - "${RABBITMQ_PORT}:5672"
+      - "${RABBITMQ_PORT_TLS}:5671"
       # OPTIONAL: Expose the GUI port
       - "${RABBITMQ_GUI_PORT}:15672"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - "${RABBITMQ_PORT_TLS}:5671"
       # OPTIONAL: Expose the GUI port
       - "${RABBITMQ_GUI_PORT}:15672"
+    volumes:
+      - ${BASE_PATH}/storage/rabbitmq_conf/rabbitmq.conf/:/etc/rabbitmq/rabbitmq.config
     networks:
       - gateway
 

--- a/mrsal/mrsal.py
+++ b/mrsal/mrsal.py
@@ -214,11 +214,11 @@ class Mrsal:
 
         """
         context = ssl.create_default_context(
-            cafile=os.environ.get('RABBIT_CAFILE')
+            cafile=os.environ.get('RABBITMQ_CAFILE')
         )
         context.load_cert_chain(
-            certfile=os.environ.get('RABBIT_CERT'),
-            keyfile=os.environ.get('RABBIT_KEY')
+            certfile=os.environ.get('RABBITMQ_CERT'),
+            keyfile=os.environ.get('RABBITMQ_KEY')
         )
         return context
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
 [tool.poetry]
-authors = ["Raafat <rafatzahran90@gmail.com>", "Jon E Nesvold <jnesvold@pm.me>"]
-description = ""
 name = "mrsal"
-version = "0.2.7-alpha"
+version = "0.2.9-alpha"
+description = "Mrsal is a simple to use message broker abstraction on top of RabbitMQ and Pika."
+authors = ["Raafat <rafatzahran90@gmail.com>", "Jon E Nesvold <jnesvold@pm.me>"]
+maintainers = ["Raafat <rafatzahran90@gmail.com>", "Jon E Nesvold <jnesvold@pm.me>"]
+keywords = ["RabbitMQ", "Pika", "Mrsal"]
+readme = "README.md"
+license = ""
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/storage/rabbitmq_conf/rabbitmq.conf
+++ b/storage/rabbitmq_conf/rabbitmq.conf
@@ -1,0 +1,6 @@
+[
+  {rabbit, [
+      {max_message_size, [536870912]}
+    ]
+  }
+].

--- a/tests/test_exchange_types/test_for_readme.py
+++ b/tests/test_exchange_types/test_for_readme.py
@@ -1,0 +1,88 @@
+import json
+import time
+
+import mrsal.config.config as config
+import pika
+import tests.config as test_config
+from mrsal.config.logging import get_logger
+from mrsal.mrsal import Mrsal
+
+log = get_logger(__name__)
+
+mrsal = Mrsal(host=test_config.HOST,
+             port=config.RABBITMQ_PORT,
+             credentials=config.RABBITMQ_CREDENTIALS,
+             virtual_host=config.V_HOST)
+mrsal.connect_to_server()
+
+def test_basic_workflow():
+
+    # Delete existing queues and exchanges to use
+    mrsal.exchange_delete(exchange='friendship')
+    mrsal.queue_delete(queue='friendship_queue')
+    # ------------------------------------------
+
+    # Publisher:
+    prop = pika.BasicProperties(
+        app_id='friendship_app',
+        message_id='friendship_msg',
+        content_type='text/plain',
+        content_encoding='utf-8',
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
+
+    # Message is published to the exchange and it's routed to queue
+    message_body = 'Hello'
+    mrsal.publish_message(exchange='friendship',
+                         exchange_type='direct',
+                         queue='friendship_queue',
+                         routing_key='friendship_key',
+                         message=json.dumps(message_body), 
+                         prop=prop,
+                         fast_setup=True)
+    # ------------------------------------------
+
+    time.sleep(1)
+    # Confirm messages are routed to respected queue
+    result1 = mrsal.setup_queue(queue='friendship_queue', passive=True)
+    message_count1 = result1.method.message_count
+    assert message_count1 == 1
+    # ------------------------------------------
+
+    # Start consumer 
+    mrsal.start_consumer(
+        queue='friendship_queue',
+        callback=consumer_callback_with_delivery_info,
+        callback_args=(test_config.HOST, 'friendship_queue'),
+        inactivity_timeout=1,
+        requeue=False,
+        callback_with_delivery_info=True
+    )
+
+    # ------------------------------------------
+
+    # Confirm messages are consumed
+    result1 = mrsal.setup_queue(queue='friendship_queue', passive=True)
+    message_count1 = result1.method.message_count
+    assert message_count1 == 0
+
+
+def consumer_callback_with_delivery_info(host_param: str, queue_param: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str):
+    str_message = json.loads(message_param).replace('"', '')
+    if 'Hello' in str_message:
+        app_id = properties.app_id
+        msg_id = properties.message_id
+        print(f'app_id={app_id}, msg_id={msg_id}')
+        print('Salaam habibi')
+        return True  # Consumed message processed correctly
+    return False
+
+def consumer_callback(host_param: str, queue_param: str, message_param: str):
+    str_message = json.loads(message_param).replace('"', '')
+    if 'Hello' in str_message:
+        print('Salaam habibi')
+        return True  # Consumed message processed correctly
+    return False
+
+if __name__ == '__main__':
+    test_basic_workflow()

--- a/tests/test_fast_setup/test_fast_setup.py
+++ b/tests/test_fast_setup/test_fast_setup.py
@@ -9,15 +9,18 @@ from mrsal.mrsal import Mrsal
 
 log = get_logger(__name__)
 
-mrsal = Mrsal(
-    # host=test_config.HOST,
-    host=config.RABBIT_DOMAIN,
-    port=config.RABBITMQ_PORT_TLS,
-    ssl=True,
-    credentials=config.RABBITMQ_CREDENTIALS,
-    virtual_host=config.V_HOST
-)
+# mrsal = Mrsal(
+#     host=config.RABBIT_DOMAIN,
+#     port=config.RABBITMQ_PORT_TLS,
+#     ssl=True,
+#     credentials=config.RABBITMQ_CREDENTIALS,
+#     virtual_host=config.V_HOST
+# )
 
+mrsal = Mrsal(host=test_config.HOST,
+             port=config.RABBITMQ_PORT,
+             credentials=config.RABBITMQ_CREDENTIALS,
+             virtual_host=config.V_HOST)
 
 mrsal.connect_to_server()
 


### PR DESCRIPTION
- Modify `max_message_size` and set it to the max value `536870912`:
   - The largest allowed message payload size in bytes. 
   - Messages of larger size will be rejected with a suitable channel exception.
   - Default: `134217728`
   - Max value: `536870912`
- Reformat README and FullGuide with the new params of `publish_message` and  `start_consumer`.