### PR TITLE
MRSAL-7: Redeliver with delay and test quorum queue

### DIFF
--- a/FullGuide.md
+++ b/FullGuide.md
@@ -23,6 +23,8 @@
     * [Delay Exchange](#delayExchange)
 - [Setup Queue With Dead Letters Exchange](#queueWithDeadLetters)
 - [Dead and Delay Letters Workflow](#deadAndDelayLetters)
+- [Redeliver Rejected Letters With Delay Workflow](#redeliverLettersWithDelay)
+- [Quorum Queue With Delivery Limit Workflow](#quorumWithDeliveryLimit)
 - [Setup Concurrent Consumers](#concurrentConsumers)
 - [Resources](#resources)
 ---  
@@ -1105,6 +1107,274 @@ mrsal.start_consumer(
     inactivity_timeout=3,
     requeue=False
 )
+```
+---
+<div id='redeliverLettersWithDelay'/>
+
+## Redeliver Rejected Letters With Delay Workflow
+
+It's possible to redeliver the rejected messages with delay time.
+
+```py
+import json
+import time
+
+import mrsal.config.config as config
+import pika
+import tests.config as test_config
+from mrsal.config.logging import get_logger
+from mrsal.mrsal import Mrsal
+
+log = get_logger(__name__)
+
+mrsal = Mrsal(host=test_config.HOST,
+              port=config.RABBITMQ_PORT,
+              credentials=config.RABBITMQ_CREDENTIALS,
+              virtual_host=config.V_HOST,
+              verbose=True)
+mrsal.connect_to_server()
+
+def test_redelivery_with_delay():
+
+    # Delete existing queues and exchanges to use
+    mrsal.exchange_delete(exchange='agreements')
+    mrsal.queue_delete(queue='agreements_queue')
+    # ------------------------------------------
+    queue_arguments = None
+    # ------------------------------------------
+
+    # Setup main exchange with delay type
+    exch_result1: pika.frame.Method = mrsal.setup_exchange(exchange='agreements',
+                                                           exchange_type='x-delayed-message',
+                                                           arguments={'x-delayed-type': 'direct'})
+    assert exch_result1 != None
+    # ------------------------------------------
+
+    # Setup main queue
+    q_result1: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue')
+    assert q_result1 != None
+
+    # Bind main queue to the main exchange with routing_key
+    qb_result1: pika.frame.Method = mrsal.setup_queue_binding(exchange='agreements',
+                                                              routing_key='agreements_key',
+                                                              queue='agreements_queue')
+    assert qb_result1 != None
+    # ------------------------------------------
+
+    """
+    Publisher:
+      Message ("uuid1") is published with delay 1 sec
+      Message ("uuid2") is published with delay 2 sec
+    """
+    message1 = 'uuid1'
+    prop1 = pika.BasicProperties(
+        app_id='test_delivery-limit',
+        message_id='msg_uuid1',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'x-delay': 1000, 'x-retry-limit': 2})
+    mrsal.publish_message(exchange='agreements',
+                          routing_key='agreements_key',
+                          message=json.dumps(message1), prop=prop1)
+
+    message2 = 'uuid2'
+    prop2 = pika.BasicProperties(
+        app_id='test_delivery-limit',
+        message_id='msg_uuid2',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'x-delay': 2000, 'x-retry-limit': 3, 'x-retry': 0})
+    mrsal.publish_message(exchange='agreements',
+                          routing_key='agreements_key',
+                          message=json.dumps(message2), prop=prop2)
+
+    # ------------------------------------------
+    # Waiting for the delay time of the messages in the exchange. Then will be delivered to the queue.
+    time.sleep(3)
+
+    # Confirm messages are published
+    result: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue', passive=True)
+    message_count = result.method.message_count
+    log.info(f'Message count in queue "agreements_queue" before consuming= {message_count}')
+    assert message_count == 2
+
+    log.info(f'===== Start consuming from "agreements_queue" ========')
+    """
+    Consumer from main queue
+      Message ("uuid1"):
+          - This message is positively-acknowledged by consumer.
+          - Then it will be deleted from queue.
+      Message ("uuid2"):
+          - This message is rejected by consumer's callback.
+          - Therefor it will be negatively-acknowledged by consumer.
+          - Then it will be redelivered with incremented x-retry until, either is acknowledged or x-retry = x-retry-limit.
+    """
+    mrsal.start_consumer(
+        queue='agreements_queue',
+        callback=consumer_callback,
+        callback_args=(test_config.HOST, 'agreements_queue'),
+        inactivity_timeout=8,
+        requeue=False,
+        callback_with_delivery_info=True
+    )
+    # ------------------------------------------
+
+    # Confirm messages are consumed
+    result: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue', passive=True)
+    message_count = result.method.message_count
+    log.info(f'Message count in queue "agreements_queue" after consuming= {message_count}')
+    assert message_count == 0
+
+def consumer_callback(host: str, queue: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message: str):
+    return message != b'"\\"uuid2\\""'
+
+
+if __name__ == '__main__':
+    test_redelivery_with_delay()
+
+```
+---
+<div id='quorumWithDeliveryLimit'/>
+
+## Quorum Queue With Delivery Limit Workflow
+
+- The quorum queue is a modern queue type for RabbitMQ implementing a durable, replicated FIFO queue based on the Raft consensus algorithm. 
+- It is available as of RabbitMQ 3.8.0.
+- It is possible to set a delivery limit for a queue using a policy argument, delivery-limit.
+
+For more info: [quorum-queues](https://www.rabbitmq.com/quorum-queues.html)
+
+```py
+import json
+import time
+
+import mrsal.config.config as config
+import pika
+import tests.config as test_config
+from mrsal.config.logging import get_logger
+from mrsal.mrsal import Mrsal
+
+log = get_logger(__name__)
+
+mrsal = Mrsal(host=test_config.HOST,
+              port=config.RABBITMQ_PORT,
+              credentials=config.RABBITMQ_CREDENTIALS,
+              virtual_host=config.V_HOST,
+              verbose=True)
+mrsal.connect_to_server()
+
+def test_quorum_delivery_limit():
+
+    # Delete existing queues and exchanges to use
+    mrsal.exchange_delete(exchange='agreements')
+    mrsal.queue_delete(queue='agreements_queue')
+    # ------------------------------------------
+    queue_arguments = {
+        # Queue of quorum type
+        'x-queue-type': 'quorum',
+        # Set a delivery limit for a queue using a policy argument, delivery-limit.
+        # When a message has been returned more times than the limit the message will be dropped 
+        # or dead-lettered(if a DLX is configured).
+        'x-delivery-limit': 3} 
+    # ------------------------------------------
+
+    # Setup main exchange
+    exch_result1: pika.frame.Method = mrsal.setup_exchange(exchange='agreements',
+                                                           exchange_type='direct')
+    assert exch_result1 != None
+    # ------------------------------------------
+
+    # Setup main queue with arguments
+    q_result1: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue',
+                                                     arguments=queue_arguments)
+    assert q_result1 != None
+
+    # Bind main queue to the main exchange with routing_key
+    qb_result1: pika.frame.Method = mrsal.setup_queue_binding(exchange='agreements',
+                                                              routing_key='agreements_key',
+                                                              queue='agreements_queue')
+    assert qb_result1 != None
+    # ------------------------------------------
+
+    """
+    Publisher:
+      Message ("uuid1") is published
+      Message ("uuid2") is published
+    """
+    message1 = 'uuid1'
+    prop1 = pika.BasicProperties(
+        app_id='test_delivery-limit',
+        message_id='msg_uuid1',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
+    mrsal.publish_message(exchange='agreements',
+                          routing_key='agreements_key',
+                          message=json.dumps(message1), prop=prop1)
+
+    message2 = 'uuid2'
+    prop2 = pika.BasicProperties(
+        app_id='test_delivery-limit',
+        message_id='msg_uuid2',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
+    mrsal.publish_message(exchange='agreements',
+                          routing_key='agreements_key',
+                          message=json.dumps(message2), prop=prop2)
+
+    # ------------------------------------------
+    time.sleep(1)
+
+    # Confirm messages are published
+    result: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue', passive=True,
+                                                  arguments=queue_arguments)
+    message_count = result.method.message_count
+    log.info(f'Message count in queue "agreements_queue" before consuming= {message_count}')
+    assert message_count == 2
+
+    log.info(f'===== Start consuming from "agreements_queue" ========')
+    """
+    Consumer from main queue
+      Message ("uuid1"):
+          - This message is positively-acknowledged by consumer.
+          - Then it will be deleted from queue.
+      Message ("uuid2"):
+          - This message is rejected by consumer's callback.
+          - Therefor it will be negatively-acknowledged by consumer.
+          - Then it will be redelivered until, either it's acknowledged or x-delivery-limit is reached.
+    """
+    mrsal.start_consumer(
+        queue='agreements_queue',
+        callback=consumer_callback,
+        callback_args=(test_config.HOST, 'agreements_queue'),
+        inactivity_timeout=1,
+        requeue=True,
+        callback_with_delivery_info=True
+    )
+    # ------------------------------------------
+
+    # Confirm messages are consumed
+    result: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue', passive=True,
+                                                  arguments=queue_arguments)
+    message_count = result.method.message_count
+    log.info(f'Message count in queue "agreements_queue" after consuming= {message_count}')
+    assert message_count == 0
+
+def consumer_callback(host: str, queue: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message: str):
+    return message != b'"\\"uuid2\\""'
+
+def consumer_dead_letters_callback(host_param: str, queue_param: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str):
+    return True
+
+
+if __name__ == '__main__':
+    test_quorum_delivery_limit()
+
 ```
 ---
 <div id='concurrentConsumers'/>

--- a/README.md
+++ b/README.md
@@ -202,4 +202,4 @@ def consumer_callback_with_delivery_info(host_param: str, queue_param: str, meth
 
 That simple! You have now setup a full advanced message queueing protocol that you can use to promote friendship or other necessary communication between your services.
 
-###### Note! Please refer to the full guide on how to use customize Mrsal to meet specific needs. There are many parameters and settings that you can use to set up a more sophisticated communication protocol.
+###### Note! Please refer to the >>>`FULL GUIDE`<<< on how to use customize Mrsal to meet specific needs. There are many parameters and settings that you can use to set up a more sophisticated communication protocol.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.9"
 
 services:
   rabbitmq_server:

--- a/mrsal/config/config.py
+++ b/mrsal/config/config.py
@@ -22,3 +22,10 @@ RABBITMQ_DEAD_LETTER_QUEUE: str = 'dead_letter-queue'
 DELAY_EXCHANGE_TYPE: str = 'x-delayed-message'
 DELAY_EXCHANGE_ARGS: Dict[str, str] = {'x-delayed-type': 'direct'}
 DEAD_LETTER_QUEUE_ARGS: Dict[str, str] = {'x-dead-letter-exchange': '', 'x-dead-letter-routing-key': ''}
+
+CONTENT_TYPE: str = 'text/plain'
+CONTENT_ENCODING: str = 'utf-8'
+
+RETRY_LIMIT_KEY: str = 'x-retry-limit'
+RETRY_KEY: str = 'x-retry'
+MESSAGE_HEADERS_KEY: str = 'headers'

--- a/mrsal/utils/utils.py
+++ b/mrsal/utils/utils.py
@@ -1,0 +1,10 @@
+import pika
+
+import mrsal.config.config as config
+
+
+def is_redelivery_configured(msg_prop: pika.spec.BasicProperties):
+    if hasattr(msg_prop, config.MESSAGE_HEADERS_KEY):
+        headers = msg_prop.headers
+        return headers is not None and config.RETRY_LIMIT_KEY in headers and config.RETRY_KEY in headers
+    return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.poetry]
 name = "mrsal"
-version = "0.4.2-alpha"
+version = "0.5.0-alpha"
 description = "Mrsal is a simple to use message broker abstraction on top of RabbitMQ and Pika."
 authors = ["Raafat <rafatzahran90@gmail.com>", "Jon E Nesvold <jnesvold@pm.me>"]
 maintainers = ["Raafat <rafatzahran90@gmail.com>", "Jon E Nesvold <jnesvold@pm.me>"]
-keywords = ["RabbitMQ", "Pika", "Mrsal"]
+keywords = ["message broker", "RabbitMQ", "Pika", "Mrsal"]
 readme = "README.md"
 license = ""
 

--- a/tests/test_delay_and_dl_messages/test_quorum_delivery_limit.py
+++ b/tests/test_delay_and_dl_messages/test_quorum_delivery_limit.py
@@ -1,0 +1,135 @@
+"""
+- The quorum queue is a modern queue type for RabbitMQ implementing a durable, replicated FIFO queue based on the Raft consensus algorithm. 
+- It is available as of RabbitMQ 3.8.0.
+- It is possible to set a delivery limit for a queue using a policy argument, delivery-limit.
+
+For more info: https://www.rabbitmq.com/quorum-queues.html
+"""
+
+import json
+import time
+
+import mrsal.config.config as config
+import pika
+import tests.config as test_config
+from mrsal.config.logging import get_logger
+from mrsal.mrsal import Mrsal
+
+log = get_logger(__name__)
+
+mrsal = Mrsal(host=test_config.HOST,
+              port=config.RABBITMQ_PORT,
+              credentials=config.RABBITMQ_CREDENTIALS,
+              virtual_host=config.V_HOST,
+              verbose=True)
+mrsal.connect_to_server()
+
+def test_quorum_delivery_limit():
+
+    # Delete existing queues and exchanges to use
+    mrsal.exchange_delete(exchange='agreements')
+    mrsal.queue_delete(queue='agreements_queue')
+    # ------------------------------------------
+    queue_arguments = {
+        # Queue of quorum type
+        'x-queue-type': 'quorum',
+        # Set a delivery limit for a queue using a policy argument, delivery-limit.
+        # When a message has been returned more times than the limit the message will be dropped 
+        # or dead-lettered(if a DLX is configured).
+        'x-delivery-limit': 3} 
+    # ------------------------------------------
+
+    # Setup main exchange
+    exch_result1: pika.frame.Method = mrsal.setup_exchange(exchange='agreements',
+                                                           exchange_type='direct')
+    assert exch_result1 != None
+    # ------------------------------------------
+
+    # Setup main queue with arguments
+    q_result1: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue',
+                                                     arguments=queue_arguments)
+    assert q_result1 != None
+
+    # Bind main queue to the main exchange with routing_key
+    qb_result1: pika.frame.Method = mrsal.setup_queue_binding(exchange='agreements',
+                                                              routing_key='agreements_key',
+                                                              queue='agreements_queue')
+    assert qb_result1 != None
+    # ------------------------------------------
+
+    """
+    Publisher:
+      Message ("uuid1") is published
+      Message ("uuid2") is published
+    """
+    message1 = 'uuid1'
+    prop1 = pika.BasicProperties(
+        app_id='test_delivery-limit',
+        message_id='msg_uuid1',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
+    mrsal.publish_message(exchange='agreements',
+                          routing_key='agreements_key',
+                          message=json.dumps(message1), prop=prop1)
+
+    message2 = 'uuid2'
+    prop2 = pika.BasicProperties(
+        app_id='test_delivery-limit',
+        message_id='msg_uuid2',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers=None)
+    mrsal.publish_message(exchange='agreements',
+                          routing_key='agreements_key',
+                          message=json.dumps(message2), prop=prop2)
+
+    # ------------------------------------------
+    time.sleep(1)
+
+    # Confirm messages are published
+    result: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue', passive=True,
+                                                  arguments=queue_arguments)
+    message_count = result.method.message_count
+    log.info(f'Message count in queue "agreements_queue" before consuming= {message_count}')
+    assert message_count == 2
+
+    log.info(f'===== Start consuming from "agreements_queue" ========')
+    """
+    Consumer from main queue
+      Message ("uuid1"):
+          - This message is positively-acknowledged by consumer.
+          - Then it will be deleted from queue.
+      Message ("uuid2"):
+          - This message is rejected by consumer's callback.
+          - Therefor it will be negatively-acknowledged by consumer.
+          - Then it will be redelivered until, either it's acknowledged or x-delivery-limit is reached.
+    """
+    mrsal.start_consumer(
+        queue='agreements_queue',
+        callback=consumer_callback,
+        callback_args=(test_config.HOST, 'agreements_queue'),
+        inactivity_timeout=1,
+        requeue=True,
+        callback_with_delivery_info=True
+    )
+    # ------------------------------------------
+
+    # Confirm messages are consumed
+    result: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue', passive=True,
+                                                  arguments=queue_arguments)
+    message_count = result.method.message_count
+    log.info(f'Message count in queue "agreements_queue" after consuming= {message_count}')
+    assert message_count == 0
+
+def consumer_callback(host: str, queue: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message: str):
+    return message != b'"\\"uuid2\\""'
+
+def consumer_dead_letters_callback(host_param: str, queue_param: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message_param: str):
+    return True
+
+
+if __name__ == '__main__':
+    test_quorum_delivery_limit()

--- a/tests/test_delay_and_dl_messages/test_redelivery_with_delay.py
+++ b/tests/test_delay_and_dl_messages/test_redelivery_with_delay.py
@@ -1,0 +1,117 @@
+import json
+import time
+
+import mrsal.config.config as config
+import pika
+import tests.config as test_config
+from mrsal.config.logging import get_logger
+from mrsal.mrsal import Mrsal
+
+log = get_logger(__name__)
+
+mrsal = Mrsal(host=test_config.HOST,
+              port=config.RABBITMQ_PORT,
+              credentials=config.RABBITMQ_CREDENTIALS,
+              virtual_host=config.V_HOST,
+              verbose=True)
+mrsal.connect_to_server()
+
+def test_redelivery_with_delay():
+
+    # Delete existing queues and exchanges to use
+    mrsal.exchange_delete(exchange='agreements')
+    mrsal.queue_delete(queue='agreements_queue')
+    # ------------------------------------------
+    queue_arguments = None
+    # ------------------------------------------
+
+    # Setup main exchange with delay type
+    exch_result1: pika.frame.Method = mrsal.setup_exchange(exchange='agreements',
+                                                           exchange_type='x-delayed-message',
+                                                           arguments={'x-delayed-type': 'direct'})
+    assert exch_result1 != None
+    # ------------------------------------------
+
+    # Setup main queue
+    q_result1: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue')
+    assert q_result1 != None
+
+    # Bind main queue to the main exchange with routing_key
+    qb_result1: pika.frame.Method = mrsal.setup_queue_binding(exchange='agreements',
+                                                              routing_key='agreements_key',
+                                                              queue='agreements_queue')
+    assert qb_result1 != None
+    # ------------------------------------------
+
+    """
+    Publisher:
+      Message ("uuid1") is published with delay 1 sec
+      Message ("uuid2") is published with delay 2 sec
+    """
+    message1 = 'uuid1'
+    prop1 = pika.BasicProperties(
+        app_id='test_delivery-limit',
+        message_id='msg_uuid1',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'x-delay': 1000, 'x-retry-limit': 2})
+    mrsal.publish_message(exchange='agreements',
+                          routing_key='agreements_key',
+                          message=json.dumps(message1), prop=prop1)
+
+    message2 = 'uuid2'
+    prop2 = pika.BasicProperties(
+        app_id='test_delivery-limit',
+        message_id='msg_uuid2',
+        content_type=test_config.CONTENT_TYPE,
+        content_encoding=test_config.CONTENT_ENCODING,
+        delivery_mode=pika.DeliveryMode.Persistent,
+        headers={'x-delay': 2000, 'x-retry-limit': 3, 'x-retry': 0})
+    mrsal.publish_message(exchange='agreements',
+                          routing_key='agreements_key',
+                          message=json.dumps(message2), prop=prop2)
+
+    # ------------------------------------------
+    # Waiting for the delay time of the messages in the exchange. Then will be delivered to the queue.
+    time.sleep(3)
+
+    # Confirm messages are published
+    result: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue', passive=True)
+    message_count = result.method.message_count
+    log.info(f'Message count in queue "agreements_queue" before consuming= {message_count}')
+    assert message_count == 2
+
+    log.info(f'===== Start consuming from "agreements_queue" ========')
+    """
+    Consumer from main queue
+      Message ("uuid1"):
+          - This message is positively-acknowledged by consumer.
+          - Then it will be deleted from queue.
+      Message ("uuid2"):
+          - This message is rejected by consumer's callback.
+          - Therefor it will be negatively-acknowledged by consumer.
+          - Then it will be redelivered with incremented x-retry until, either is acknowledged or x-retry = x-retry-limit.
+    """
+    mrsal.start_consumer(
+        queue='agreements_queue',
+        callback=consumer_callback,
+        callback_args=(test_config.HOST, 'agreements_queue'),
+        inactivity_timeout=8,
+        requeue=False,
+        callback_with_delivery_info=True
+    )
+    # ------------------------------------------
+
+    # Confirm messages are consumed
+    result: pika.frame.Method = mrsal.setup_queue(queue='agreements_queue', passive=True)
+    message_count = result.method.message_count
+    log.info(f'Message count in queue "agreements_queue" after consuming= {message_count}')
+    assert message_count == 0
+
+def consumer_callback(host: str, queue: str, method_frame: pika.spec.Basic.Deliver, properties: pika.spec.BasicProperties, message: str):
+    return message != b'"\\"uuid2\\""'
+
+
+if __name__ == '__main__':
+    test_redelivery_with_delay()


### PR DESCRIPTION
- It's possible to **redeliver** the rejected messages with **delay** time.
- **Quorum** queue:
   - The quorum queue is a modern queue type for RabbitMQ implementing a durable, replicated FIFO queue based on the Raft consensus algorithm. 
   - It is available as of RabbitMQ 3.8.0.
   - It is possible to set a delivery limit for a queue using a policy argument, `delivery-limit`.