### PR TITLE
Integration test suite for mrsal added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MRSAL AMQP
-[![Release](https://img.shields.io/badge/release-3.8.2-blue.svg)](https://pypi.org/project/mrsal/) 
+[![Release](https://img.shields.io/badge/release-3.8.3-blue.svg)](https://pypi.org/project/mrsal/) 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%7C3.11%7C3.12-blue.svg)](https://www.python.org/downloads/)
 [![Mrsal Workflow](https://github.com/NeoMedSys/mrsal/actions/workflows/mrsal.yaml/badge.svg?branch=main)](https://github.com/NeoMedSys/mrsal/actions/workflows/mrsal.yaml)
 [![Coverage](https://neomedsys.github.io/mrsal/reports/badges/coverage-badge.svg)](https://neomedsys.github.io/mrsal/reports/coverage/htmlcov/)

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,6 +53,9 @@ def tests(session: Session):
             "./tests",
             "--junitxml=./reports/junit/junit.xml",
             "--ignore=./tests/test_ssl",
+            # Integration tests require a live RabbitMQ broker; they live in
+            # their own session (``nox -s integration``) so unit runs stay fast.
+            "--ignore=./tests/integration",
             external=True,
         )
 
@@ -68,6 +71,33 @@ def tests(session: Session):
         session.log("Tests and coverage reporting complete.")
     except Exception as e:
         session.error(f"Tests failed: {e}")
+
+
+@nox.session(name="integration", reuse_venv=True)
+def integration(session: Session):
+    """
+    Run integration tests against a real RabbitMQ broker.
+
+    Requires the broker to be reachable (default ``localhost:5672`` with
+    ``guest`` / ``guest``). Bring one up with::
+
+        docker compose -f tests/integration/docker-compose.yml up -d
+
+    Override the endpoint via ``MRSAL_IT_HOST`` / ``MRSAL_IT_PORT`` /
+    ``MRSAL_IT_USER`` / ``MRSAL_IT_PASS`` / ``MRSAL_IT_VHOST``.
+    """
+    try:
+        session.run("poetry", "install", "--with", "dev", external=True)
+        session.run(
+            "poetry", "run", "pytest",
+            "./tests/integration",
+            "-m", "integration",
+            "-v",
+            external=True,
+        )
+        session.log("Integration tests complete.")
+    except Exception as e:
+        session.error(f"Integration tests failed: {e}")
 
 
 @nox.session(name="lint", reuse_venv=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-or-later"
 maintainers = ["Jon E Nesvold <jnesvold@neomedsys.io>"]
 name = "mrsal"
 readme = "README.md"
-version = "3.8.2"
+version = "3.8.3"
 homepage = "https://github.com/NeoMedSys/mrsal"
 repository = "https://github.com/NeoMedSys/mrsal"
 documentation = "https://neomedsys.github.io/mrsal/"
@@ -44,3 +44,9 @@ pytest-asyncio = "^1.3.0"
 [build-system]
 build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core>=1.0.0"]
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests that require a live RabbitMQ broker (deselected from the default unit-test run)",
+]
+

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,267 @@
+"""Shared fixtures and helpers for integration tests.
+
+The broker is expected to be reachable on the address resolved from
+``MRSAL_IT_HOST`` / ``MRSAL_IT_PORT`` (default ``localhost:5673``) with
+``MRSAL_IT_USER`` / ``MRSAL_IT_PASS`` (default ``guest`` / ``guest``).
+
+If the broker is not reachable, the whole module is skipped with a clear
+message instead of producing a wall of connection-refused tracebacks.
+"""
+import asyncio
+import os
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+
+import pika
+import pytest
+
+
+BROKER_HOST = os.environ.get("MRSAL_IT_HOST", "localhost")
+
+
+def _resolve_broker_port() -> int:
+    """Parse ``MRSAL_IT_PORT`` with a clear error if it isn't an integer.
+
+    Module-load parse failures otherwise surface as a confusing ``ValueError``
+    during collection — a misconfigured env var should fail loudly with the
+    actual offending value.
+    """
+    raw = os.environ.get("MRSAL_IT_PORT", "5673")
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"MRSAL_IT_PORT must be an integer, got {raw!r}"
+        ) from exc
+
+
+BROKER_PORT = _resolve_broker_port()
+BROKER_USER = os.environ.get("MRSAL_IT_USER", "guest")
+BROKER_PASS = os.environ.get("MRSAL_IT_PASS", "guest")
+BROKER_VHOST = os.environ.get("MRSAL_IT_VHOST", "/")
+
+
+def _broker_reachable() -> bool:
+    """Open a short AMQP connection so wrong-creds / wrong-vhost also skip.
+
+    A pure TCP probe wrongly reports "broker up" when the port is open but
+    auth is misconfigured, leaving the tests to fail with
+    ``ProbableAuthenticationError`` everywhere. The brief AMQP handshake
+    costs ~0.5s once per session but produces a useful skip reason.
+    """
+    try:
+        conn = pika.BlockingConnection(
+            pika.ConnectionParameters(
+                host=BROKER_HOST,
+                port=BROKER_PORT,
+                credentials=pika.PlainCredentials(BROKER_USER, BROKER_PASS),
+                virtual_host=BROKER_VHOST,
+                heartbeat=10,
+                blocked_connection_timeout=5,
+                socket_timeout=3,
+            )
+        )
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip every integration test if the broker isn't usable from this run."""
+    if _broker_reachable():
+        return
+    skip = pytest.mark.skip(
+        reason=(
+            f"RabbitMQ broker not reachable at {BROKER_HOST}:{BROKER_PORT} "
+            f"as {BROKER_USER}@{BROKER_VHOST} — start it with "
+            "`docker compose -f tests/integration/docker-compose.yml up -d`"
+        )
+    )
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip)
+
+
+def broker_setup_args(**overrides) -> dict:
+    """Kwargs for instantiating ``MrsalBlockingAMQP`` / ``MrsalAsyncAMQP``."""
+    args = {
+        "host": BROKER_HOST,
+        "port": BROKER_PORT,
+        "credentials": (BROKER_USER, BROKER_PASS),
+        "virtual_host": BROKER_VHOST,
+        "heartbeat": 60,
+        "prefetch_count": 5,
+    }
+    args.update(overrides)
+    return args
+
+
+@pytest.fixture
+def unique_suffix() -> str:
+    """Short unique tag so concurrent test runs don't collide on queue names."""
+    return uuid.uuid4().hex[:8]
+
+
+@contextmanager
+def raw_pika_channel():
+    """Open a short-lived pika channel for setup / teardown / inspection.
+
+    Kept separate from the mrsal-owned connection so that broker state can be
+    inspected even when the mrsal consumer/publisher channels are closed mid-test.
+    """
+    conn = pika.BlockingConnection(
+        pika.ConnectionParameters(
+            host=BROKER_HOST,
+            port=BROKER_PORT,
+            credentials=pika.PlainCredentials(BROKER_USER, BROKER_PASS),
+            virtual_host=BROKER_VHOST,
+            heartbeat=30,
+        )
+    )
+    try:
+        yield conn.channel()
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def cleanup_topology():
+    """Track exchanges/queues to delete after the test.
+
+    Append names with ``cleanup_topology.exchange(name)`` / ``.queue(name)``;
+    teardown runs even if the test raises. Deletion failures are swallowed so
+    a missing resource (e.g. never declared) doesn't mask the real test error.
+    """
+    exchanges: list[str] = []
+    queues: list[str] = []
+
+    class _Tracker:
+        def exchange(self, name: str) -> None:
+            exchanges.append(name)
+
+        def queue(self, name: str) -> None:
+            queues.append(name)
+
+    tracker = _Tracker()
+    yield tracker
+
+    with raw_pika_channel() as ch:
+        for q in queues:
+            try:
+                ch.queue_delete(queue=q)
+            except Exception:
+                pass
+        for e in exchanges:
+            try:
+                ch.exchange_delete(exchange=e)
+            except Exception:
+                pass
+
+
+class SyncConsumerRunner:
+    """Run ``MrsalBlockingAMQP.start_consumer`` in a daemon thread.
+
+    Wraps the boilerplate every sync integration test was repeating:
+    thread, error capture, wait-until-declared, and clean iterator cancel.
+    ``wait_ready`` surfaces a consumer-thread exception immediately instead
+    of letting the test fail later with a stale "never finished declaring"
+    message.
+    """
+
+    def __init__(self, consumer):
+        self.consumer = consumer
+        self.errors: list[Exception] = []
+        self._thread: threading.Thread | None = None
+
+    def start(self, **start_consumer_kwargs) -> None:
+        def _run():
+            try:
+                self.consumer.start_consumer(**start_consumer_kwargs)
+            except Exception as exc:
+                self.errors.append(exc)
+
+        self._thread = threading.Thread(target=_run, daemon=True)
+        self._thread.start()
+
+    def wait_ready(self, timeout: float = 10.0) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.errors:
+                raise AssertionError(
+                    f"Consumer thread raised before topology declared: {self.errors[0]!r}"
+                )
+            if (
+                self.consumer._consumer_channel is not None
+                and self.consumer.auto_declare_ok
+            ):
+                return
+            time.sleep(0.05)
+        raise AssertionError(
+            f"Consumer didn't finish declaring topology within {timeout}s"
+        )
+
+    def stop(self, timeout: float = 10.0) -> None:
+        c = self.consumer
+        if c._consumer_channel is not None and c._connection is not None:
+            try:
+                c._connection.add_callback_threadsafe(c._consumer_channel.cancel)
+            except Exception:
+                pass
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+
+    def raise_if_thread_errored(self) -> None:
+        if self.errors:
+            raise AssertionError(f"Consumer thread raised: {self.errors[0]!r}")
+
+
+class AsyncConsumerRunner:
+    """Run ``MrsalAsyncAMQP.start_consumer`` in an asyncio task.
+
+    Same role as ``SyncConsumerRunner`` for the async path. ``wait_ready``
+    fails fast if the consumer task has already errored, so the surrounding
+    test gets the real exception instead of a "never declared" timeout.
+    """
+
+    def __init__(self, consumer):
+        self.consumer = consumer
+        self._task: asyncio.Task | None = None
+
+    def start(self, **start_consumer_kwargs) -> None:
+        self._task = asyncio.create_task(
+            self.consumer.start_consumer(**start_consumer_kwargs)
+        )
+
+    async def wait_ready(self, timeout: float = 10.0) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._task is not None and self._task.done():
+                exc = self._task.exception()
+                if exc is not None:
+                    raise AssertionError(
+                        f"Async consumer task errored before ready: {exc!r}"
+                    ) from exc
+            if self.consumer.auto_declare_ok and self.consumer._channel is not None:
+                return
+            await asyncio.sleep(0.05)
+        raise AssertionError(
+            f"Async consumer didn't finish declaring topology within {timeout}s"
+        )
+
+    async def stop(self, timeout: float = 10.0) -> None:
+        await self.consumer.stop()
+        if self._task is not None:
+            try:
+                await asyncio.wait_for(self._task, timeout=timeout)
+            except asyncio.TimeoutError:
+                self._task.cancel()
+                try:
+                    await self._task
+                except (asyncio.CancelledError, Exception):
+                    pass

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -151,6 +151,10 @@ def cleanup_topology():
     tracker = _Tracker()
     yield tracker
 
+    # ``queue_delete`` removes the queue's bindings implicitly — that's why the
+    # tracker doesn't need to track ``.retry`` -> DLX exchange bindings
+    # separately. If a future test asserts on binding state directly, switch
+    # to explicit ``queue_unbind`` before delete.
     with raw_pika_channel() as ch:
         for q in queues:
             try:
@@ -207,6 +211,17 @@ class SyncConsumerRunner:
         )
 
     def stop(self, timeout: float = 10.0) -> None:
+        # Two cooperating exit mechanisms here:
+        #   1. ``BlockingChannel.cancel()`` (no-arg) cancels every active
+        #      consumer on the channel and drains the generator returned by
+        #      ``channel.consume(...)``, so the ``for ... in consume(...)``
+        #      loop inside ``start_consumer`` exits with StopIteration on
+        #      its next iteration. Scheduled via ``add_callback_threadsafe``
+        #      because pika channels are owned by the consumer thread.
+        #   2. As a safety net, every test passes ``inactivity_timeout=1`` so
+        #      the consume loop wakes up at least once per second — if (1)
+        #      ever stops working on a future pika version, the loop will
+        #      still drain on its own once the broker side falls quiet.
         c = self.consumer
         if c._consumer_channel is not None and c._connection is not None:
             try:

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,0 +1,24 @@
+# Local RabbitMQ for mrsal integration tests.
+#
+# Usage:
+#   docker compose -f tests/integration/docker-compose.yml up -d
+#   poetry run nox -s integration
+#   docker compose -f tests/integration/docker-compose.yml down -v
+#
+# Override broker endpoint with MRSAL_IT_HOST / MRSAL_IT_PORT if you point the
+# tests at a different broker (e.g. a CI service container).
+services:
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    container_name: mrsal-it-rabbitmq
+    # Host ports are off the RabbitMQ defaults to avoid colliding with a
+    # locally-running dev broker. The integration tests default
+    # to MRSAL_IT_PORT=5673 to match.
+    ports:
+      - "5673:5672"
+      - "15673:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
+      interval: 5s
+      timeout: 5s
+      retries: 20

--- a/tests/integration/test_async_concurrency.py
+++ b/tests/integration/test_async_concurrency.py
@@ -1,0 +1,103 @@
+"""Async consumer concurrency exercised against a real broker.
+
+Follow-up to #74: ``max_concurrent_tasks`` was added so the async consumer can
+process N messages in parallel, bounded by an ``asyncio.Semaphore``. Mocked
+unit tests can verify the dispatch logic but not that the broker keeps feeding
+deliveries under load. This test checks that, with prefetch and concurrent
+tasks both > 1, the consumer actually observes multiple in-flight callbacks
+at the same time.
+"""
+import asyncio
+
+import pika
+import pytest
+
+from mrsal.amqp.subclass import MrsalAsyncAMQP
+
+from tests.integration.conftest import AsyncConsumerRunner, broker_setup_args, raw_pika_channel
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_consumer_processes_messages_concurrently(
+    unique_suffix, cleanup_topology,
+):
+    exchange = f"mrsal.it.cc.{unique_suffix}"
+    queue = f"mrsal.it.cc.{unique_suffix}.q"
+    routing_key = f"mrsal.it.cc.{unique_suffix}.rk"
+    cleanup_topology.exchange(exchange)
+    cleanup_topology.queue(queue)
+
+    max_concurrent_tasks = 4
+    num_messages = 8
+
+    # asyncio is single-threaded, so these counters don't need locking — every
+    # ``+= 1`` runs to completion between awaits.
+    state = {"active": 0, "max_observed": 0, "completed": 0}
+    done = asyncio.Event()
+
+    async def callback(message, properties, body):
+        state["active"] += 1
+        state["max_observed"] = max(state["max_observed"], state["active"])
+        try:
+            # Hold the slot long enough that the next iterator pull happens
+            # while this task is still active — that's what surfaces concurrency.
+            await asyncio.sleep(0.3)
+        finally:
+            state["active"] -= 1
+            state["completed"] += 1
+            if state["completed"] >= num_messages:
+                done.set()
+
+    consumer = MrsalAsyncAMQP(**broker_setup_args(prefetch_count=num_messages))
+    runner = AsyncConsumerRunner(consumer)
+    runner.start(
+        queue_name=queue,
+        exchange_name=exchange,
+        exchange_type="direct",
+        routing_key=routing_key,
+        callback=callback,
+        auto_ack=False,
+        dlx_enable=False,
+        enable_retry_cycles=False,
+        use_quorum_queues=False,
+        max_concurrent_tasks=max_concurrent_tasks,
+    )
+
+    try:
+        await runner.wait_ready()
+
+        # Publish in a thread to avoid blocking the loop while pika does I/O.
+        def publish_all() -> None:
+            with raw_pika_channel() as ch:
+                for i in range(num_messages):
+                    ch.basic_publish(
+                        exchange=exchange,
+                        routing_key=routing_key,
+                        body=f"msg-{i}".encode(),
+                        properties=pika.BasicProperties(delivery_mode=2),
+                    )
+
+        await asyncio.to_thread(publish_all)
+
+        await asyncio.wait_for(done.wait(), timeout=20)
+    finally:
+        await runner.stop()
+        await consumer.close()
+
+    assert state["completed"] == num_messages, (
+        f"Expected {num_messages} messages processed, got {state['completed']}"
+    )
+    # With prefetch_count >= max_concurrent_tasks and async-sleeping callbacks,
+    # the semaphore bound should be reached. Anything below ``max-1`` means
+    # the dispatch path regressed to near-sequential — the whole point of #74.
+    # The ``-1`` slack absorbs scheduling jitter on heavily loaded CI machines
+    # without weakening the regression signal.
+    assert state["max_observed"] >= max_concurrent_tasks - 1, (
+        f"Expected near-saturated concurrency (>= {max_concurrent_tasks - 1}); "
+        f"max observed in-flight was {state['max_observed']}"
+    )
+    assert state["max_observed"] <= max_concurrent_tasks, (
+        f"Semaphore bound violated: max observed in-flight was "
+        f"{state['max_observed']}, bound is {max_concurrent_tasks}"
+    )

--- a/tests/integration/test_async_dlx.py
+++ b/tests/integration/test_async_dlx.py
@@ -1,0 +1,122 @@
+"""Async DLX path with retry cycles against a real broker.
+
+Mirror of ``test_dlx_retry_cycle.py`` for ``MrsalAsyncAMQP``. The sync and
+async DLX paths are separate implementations (``_publish_to_dlx_with_retry_cycle``
+vs ``_async_publish_to_dlx_with_retry_cycle``) that share only the
+``_build_dlx_retry_properties`` helper, so they can drift in subtle ways.
+Asserting both end-to-end against a real broker is the cheapest way to keep
+them honest.
+
+Forces the terminal DLX path with ``max_retry_time_limit=0`` for the same
+reason as the sync test — avoids waiting on the minute-grained ``.retry``
+queue TTL.
+"""
+import asyncio
+import json
+import time
+
+import pika
+import pytest
+
+from mrsal import config
+from mrsal.amqp.subclass import MrsalAsyncAMQP
+
+from tests.integration.conftest import AsyncConsumerRunner, broker_setup_args, raw_pika_channel
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_async_failed_callback_routes_to_dlx_with_custom_routing_key(
+    unique_suffix, cleanup_topology,
+):
+    exchange = f"mrsal.it.adlx.{unique_suffix}"
+    queue = f"mrsal.it.adlx.{unique_suffix}.q"
+    routing_key = f"mrsal.it.adlx.{unique_suffix}.rk"
+    dlx_routing_key = f"mrsal.it.adlx.{unique_suffix}.custom"
+
+    cleanup_topology.exchange(exchange)
+    cleanup_topology.exchange(f"{exchange}{config.DLX_SUFFIX}")
+    cleanup_topology.queue(queue)
+    cleanup_topology.queue(f"{queue}{config.DLX_SUFFIX}")
+    cleanup_topology.queue(f"{queue}{config.RETRY_SUFFIX}")
+
+    callback_done = asyncio.Event()
+
+    consumer = MrsalAsyncAMQP(**broker_setup_args())
+    runner = AsyncConsumerRunner(consumer)
+
+    async def failing_callback(message, properties, body):
+        callback_done.set()
+        raise RuntimeError("boom — deliberate failure to drive the async DLX path")
+
+    runner.start(
+        queue_name=queue,
+        exchange_name=exchange,
+        exchange_type="direct",
+        routing_key=routing_key,
+        callback=failing_callback,
+        auto_ack=False,
+        dlx_enable=True,
+        dlx_routing_key=dlx_routing_key,
+        enable_retry_cycles=True,
+        max_retry_time_limit=0,
+        retry_cycle_interval=1,
+        use_quorum_queues=False,
+    )
+
+    try:
+        await runner.wait_ready()
+
+        payload = json.dumps({"id": 2, "msg": "async DLX"}).encode("utf-8")
+
+        # Publish via sync pika in a worker thread — keeps this test simple
+        # and matches the production pattern where async consumers often
+        # receive from sync producers.
+        def publish_one() -> None:
+            with raw_pika_channel() as ch:
+                ch.basic_publish(
+                    exchange=exchange,
+                    routing_key=routing_key,
+                    body=payload,
+                    properties=pika.BasicProperties(delivery_mode=2),
+                )
+
+        await asyncio.to_thread(publish_one)
+        await asyncio.wait_for(callback_done.wait(), timeout=10)
+
+        # Poll the terminal .dlx queue for the DLX'd message. One pika channel
+        # is held open in a worker thread for the whole poll — opening a fresh
+        # connection per attempt would burn an AMQP handshake every 100ms.
+        dlx_queue = f"{queue}{config.DLX_SUFFIX}"
+
+        def poll_dlx():
+            with raw_pika_channel() as ch:
+                deadline = time.monotonic() + 10
+                while time.monotonic() < deadline:
+                    method, props, body = ch.basic_get(queue=dlx_queue, auto_ack=True)
+                    if method is not None:
+                        return method, props, body
+                    time.sleep(0.1)
+                return None, None, None
+
+        method, props, body = await asyncio.to_thread(poll_dlx)
+
+        assert method is not None, f"No message arrived in {dlx_queue} within 10s"
+        assert body == payload, "Async DLX payload should match the original publish"
+        assert method.routing_key == dlx_routing_key, (
+            f"Expected async DLX routing_key={dlx_routing_key!r}, got {method.routing_key!r}"
+        )
+
+        headers = props.headers or {}
+        assert headers.get("x-retry-exhausted") is True, (
+            f"Terminal async DLX message should be marked exhausted; headers={headers!r}"
+        )
+        assert "x-processing-error" in headers, (
+            f"Async DLX message should carry the processing error reason; headers={headers!r}"
+        )
+        assert headers.get("x-cycle-count") == 1, (
+            f"Cycle count should increment to 1 on first failure; headers={headers!r}"
+        )
+    finally:
+        await runner.stop()
+        await consumer.close()

--- a/tests/integration/test_dlx_retry_cycle.py
+++ b/tests/integration/test_dlx_retry_cycle.py
@@ -1,0 +1,123 @@
+"""DLX path with retry cycles against a real broker.
+
+Closes the gap behind Issue 1b: with ``dlx_routing_key`` set, the bound DLX
+routing key must be the one actually used at publish time, otherwise the
+parked message lands somewhere no consumer is listening.
+
+We force the terminal DLX path by setting ``max_retry_time_limit=0`` — the
+first failure is treated as retry-exhausted and goes straight to the
+``.dlx`` queue. That avoids waiting on the minute-grained ``x-message-ttl``
+of the ``.retry`` queue, which would make the test impractically slow.
+"""
+import json
+import threading
+import time
+
+import pytest
+
+from mrsal import config
+from mrsal.amqp.subclass import MrsalBlockingAMQP
+
+from tests.integration.conftest import SyncConsumerRunner, broker_setup_args, raw_pika_channel
+
+
+@pytest.mark.integration
+def test_failed_callback_routes_to_dlx_with_custom_routing_key(
+    unique_suffix, cleanup_topology,
+):
+    exchange = f"mrsal.it.dlx.{unique_suffix}"
+    queue = f"mrsal.it.dlx.{unique_suffix}.q"
+    routing_key = f"mrsal.it.dlx.{unique_suffix}.rk"
+    dlx_routing_key = f"mrsal.it.dlx.{unique_suffix}.custom"
+
+    cleanup_topology.exchange(exchange)
+    cleanup_topology.exchange(f"{exchange}{config.DLX_SUFFIX}")
+    cleanup_topology.queue(queue)
+    cleanup_topology.queue(f"{queue}{config.DLX_SUFFIX}")
+    cleanup_topology.queue(f"{queue}{config.RETRY_SUFFIX}")
+
+    callback_done = threading.Event()
+
+    consumer = MrsalBlockingAMQP(**broker_setup_args())
+    runner = SyncConsumerRunner(consumer)
+
+    def failing_callback(method_frame, properties, body):
+        callback_done.set()
+        raise RuntimeError("boom — deliberate failure to drive the DLX path")
+
+    # max_retry_time_limit=0 short-circuits the cycle: the very first failure
+    # is treated as retry-exhausted, so the message routes directly to the
+    # terminal .dlx queue with the configured ``dlx_routing_key`` (instead of
+    # the .retry binding).
+    runner.start(
+        queue_name=queue,
+        exchange_name=exchange,
+        exchange_type="direct",
+        routing_key=routing_key,
+        callback=failing_callback,
+        auto_ack=False,
+        dlx_enable=True,
+        dlx_routing_key=dlx_routing_key,
+        enable_retry_cycles=True,
+        max_retry_time_limit=0,
+        retry_cycle_interval=1,
+        use_quorum_queues=False,
+        inactivity_timeout=1,
+    )
+
+    publisher = MrsalBlockingAMQP(**broker_setup_args())
+    payload = json.dumps({"id": 1, "msg": "to be DLX'd"}).encode("utf-8")
+    try:
+        runner.wait_ready()
+
+        publisher.publish_message(
+            exchange_name=exchange,
+            routing_key=routing_key,
+            message=payload,
+            exchange_type="direct",
+            queue_name=queue,
+            auto_declare=False,
+        )
+
+        assert callback_done.wait(timeout=10), "Failing callback was never invoked"
+
+        # Poll the terminal .dlx queue. basic_get is single-shot, so we retry
+        # briefly to absorb the lag between the consumer ack'ing the original
+        # and the DLX publish becoming visible. One channel held open for the
+        # whole poll — opening a fresh connection per attempt would burn a
+        # handshake every 100ms.
+        dlx_queue = f"{queue}{config.DLX_SUFFIX}"
+        method = props = body = None
+        with raw_pika_channel() as ch:
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                method, props, body = ch.basic_get(queue=dlx_queue, auto_ack=True)
+                if method is not None:
+                    break
+                time.sleep(0.1)
+
+        assert method is not None, f"No message arrived in {dlx_queue} within 10s"
+        assert body == payload, "DLX payload should match the original publish"
+        # The routing key used at publish time is what surfaces on the
+        # delivered message — must equal the configured dlx_routing_key
+        # (regression guard for Issue 1b).
+        assert method.routing_key == dlx_routing_key, (
+            f"Expected DLX routing_key={dlx_routing_key!r}, got {method.routing_key!r}"
+        )
+
+        headers = props.headers or {}
+        assert headers.get("x-retry-exhausted") is True, (
+            f"Terminal DLX message should be marked exhausted; headers={headers!r}"
+        )
+        assert "x-processing-error" in headers, (
+            f"DLX message should carry the processing error reason; headers={headers!r}"
+        )
+        assert headers.get("x-cycle-count") == 1, (
+            f"Cycle count should increment to 1 on first failure; headers={headers!r}"
+        )
+    finally:
+        runner.stop()
+        publisher.close()
+        consumer.close()
+
+    runner.raise_if_thread_errored()

--- a/tests/integration/test_payload_model.py
+++ b/tests/integration/test_payload_model.py
@@ -1,0 +1,81 @@
+"""Pydantic ``payload_model`` round-trip against a real broker.
+
+Closes Issue 1c regression: when ``payload_model`` is set, the callback must
+receive the *validated* model instance — not the raw bytes body. Pre-fix,
+``validate_payload`` constructed the model and dropped the result, so users
+still had to ``MyModel(**json.loads(body))`` inside every callback.
+"""
+import json
+import threading
+
+import pytest
+
+from mrsal.amqp.subclass import MrsalBlockingAMQP
+
+from tests.conftest import ExpectedPayload
+from tests.integration.conftest import SyncConsumerRunner, broker_setup_args
+
+
+@pytest.mark.integration
+def test_callback_receives_validated_model_instance(unique_suffix, cleanup_topology):
+    exchange = f"mrsal.it.pm.{unique_suffix}"
+    queue = f"mrsal.it.pm.{unique_suffix}.q"
+    routing_key = f"mrsal.it.pm.{unique_suffix}.rk"
+    cleanup_topology.exchange(exchange)
+    cleanup_topology.queue(queue)
+
+    received: list = []
+    callback_done = threading.Event()
+
+    consumer = MrsalBlockingAMQP(**broker_setup_args())
+    runner = SyncConsumerRunner(consumer)
+
+    def on_message(method_frame, properties, body):
+        # ``body`` must be the validated ExpectedPayload instance, not bytes.
+        received.append(body)
+        callback_done.set()
+
+    runner.start(
+        queue_name=queue,
+        exchange_name=exchange,
+        exchange_type="direct",
+        routing_key=routing_key,
+        callback=on_message,
+        payload_model=ExpectedPayload,
+        auto_ack=False,
+        dlx_enable=False,
+        enable_retry_cycles=False,
+        use_quorum_queues=False,
+        inactivity_timeout=1,
+    )
+
+    payload_obj = {"id": 7, "name": "samurai", "active": True}
+    publisher = MrsalBlockingAMQP(**broker_setup_args())
+    try:
+        runner.wait_ready()
+
+        publisher.publish_message(
+            exchange_name=exchange,
+            routing_key=routing_key,
+            message=json.dumps(payload_obj).encode("utf-8"),
+            exchange_type="direct",
+            queue_name=queue,
+            auto_declare=False,
+        )
+
+        assert callback_done.wait(timeout=10), "Callback was never invoked"
+        assert len(received) == 1
+        delivered = received[0]
+        assert isinstance(delivered, ExpectedPayload), (
+            f"Callback got {type(delivered).__name__} instead of ExpectedPayload — "
+            "the validated instance was dropped (Issue 1c regression)"
+        )
+        assert delivered.id == 7
+        assert delivered.name == "samurai"
+        assert delivered.active is True
+    finally:
+        runner.stop()
+        publisher.close()
+        consumer.close()
+
+    runner.raise_if_thread_errored()

--- a/tests/integration/test_publisher_confirms.py
+++ b/tests/integration/test_publisher_confirms.py
@@ -1,0 +1,83 @@
+"""Publisher confirms wired up on the user-facing publish path.
+
+Closes the gap behind Issue 1a: ``publish_message`` is decorated to retry on
+``NackError`` / ``UnroutableError``, but without ``confirm_delivery()`` on the
+publish channel those exceptions can never fire. This test sets up a queue
+that rejects publishes once it's full and asserts the broker NACK actually
+surfaces (instead of returning silently and producing data loss).
+
+The queue is declared with raw pika because mrsal's auto-declare in
+``publish_message`` doesn't accept queue-overflow parameters. We then call
+``publish_message(auto_declare=False)`` so it publishes against the topology
+we've prepared.
+"""
+import pika
+import pytest
+from pika.exceptions import NackError
+from tenacity import RetryError
+
+from mrsal.amqp.subclass import MrsalBlockingAMQP
+
+from tests.integration.conftest import broker_setup_args, raw_pika_channel
+
+
+@pytest.mark.integration
+def test_publish_to_full_reject_publish_queue_surfaces_nack(
+    unique_suffix, cleanup_topology,
+):
+    exchange = f"mrsal.it.conf.{unique_suffix}"
+    queue = f"mrsal.it.conf.{unique_suffix}.q"
+    routing_key = f"mrsal.it.conf.{unique_suffix}.rk"
+    cleanup_topology.exchange(exchange)
+    cleanup_topology.queue(queue)
+
+    # x-max-length=1 + x-overflow=reject-publish gives us a deterministic
+    # NACK from the broker on the second publish. Classic queue (not quorum)
+    # because reject-publish semantics are simplest to reason about there.
+    with raw_pika_channel() as ch:
+        ch.exchange_declare(
+            exchange=exchange, exchange_type="direct", durable=True,
+        )
+        ch.queue_declare(
+            queue=queue,
+            durable=True,
+            arguments={
+                "x-max-length": 1,
+                "x-overflow": "reject-publish",
+            },
+        )
+        ch.queue_bind(exchange=exchange, queue=queue, routing_key=routing_key)
+
+    publisher = MrsalBlockingAMQP(**broker_setup_args())
+
+    def publish_once(body: bytes) -> None:
+        publisher.publish_message(
+            exchange_name=exchange,
+            routing_key=routing_key,
+            message=body,
+            exchange_type="direct",
+            queue_name=queue,
+            auto_declare=False,
+            prop=pika.BasicProperties(delivery_mode=2),
+        )
+
+    try:
+        publish_once(b"first-fits")
+
+        # The second publish targets a full reject-publish queue. With
+        # ``confirm_delivery()`` wired the broker NACK has to surface as
+        # ``NackError`` (and tenacity retries it twice more before giving up
+        # with ``RetryError`` wrapping the underlying NACK). Without confirms
+        # the publish would return successfully and this test would hang here
+        # — that's the regression we're guarding against.
+        with pytest.raises((NackError, RetryError)) as exc_info:
+            publish_once(b"second-rejected")
+
+        raised = exc_info.value
+        if isinstance(raised, RetryError):
+            inner = raised.last_attempt.exception()
+            assert isinstance(inner, NackError), (
+                f"Expected NackError under RetryError, got {type(inner).__name__}: {inner!r}"
+            )
+    finally:
+        publisher.close()

--- a/tests/integration/test_round_trip.py
+++ b/tests/integration/test_round_trip.py
@@ -1,0 +1,74 @@
+"""End-to-end publish/consume against a real broker.
+
+This is the smallest meaningful integration test: it exercises the user-facing
+``publish_message`` and ``start_consumer`` paths and asserts the consumer
+callback observes the published body. Catches whole classes of regressions the
+mock-based unit tests can't (channel/exchange/queue declare ordering, prefetch,
+publisher confirms wiring, basic_ack delivery_tag flow).
+"""
+import threading
+
+import pytest
+
+from mrsal.amqp.subclass import MrsalBlockingAMQP
+
+from tests.integration.conftest import SyncConsumerRunner, broker_setup_args
+
+
+@pytest.mark.integration
+def test_publish_then_consume_delivers_body(unique_suffix, cleanup_topology):
+    exchange = f"mrsal.it.rt.{unique_suffix}"
+    queue = f"mrsal.it.rt.{unique_suffix}.q"
+    routing_key = f"mrsal.it.rt.{unique_suffix}.rk"
+    cleanup_topology.exchange(exchange)
+    cleanup_topology.queue(queue)
+
+    payload = b"round-trip-body"
+    received: list[bytes] = []
+    callback_done = threading.Event()
+
+    consumer = MrsalBlockingAMQP(**broker_setup_args())
+    runner = SyncConsumerRunner(consumer)
+
+    def on_message(method_frame, properties, body):
+        received.append(body)
+        callback_done.set()
+
+    # use_quorum_queues=True exercises the broker actually accepting the
+    # ``x-queue-type=quorum`` declare. Mock tests can't validate broker-side
+    # acceptance of those args, so doing it here gives us a regression guard
+    # on the library's default queue type for free.
+    runner.start(
+        queue_name=queue,
+        exchange_name=exchange,
+        exchange_type="direct",
+        routing_key=routing_key,
+        callback=on_message,
+        auto_ack=False,
+        dlx_enable=False,
+        enable_retry_cycles=False,
+        use_quorum_queues=True,
+        inactivity_timeout=1,
+    )
+
+    publisher = MrsalBlockingAMQP(**broker_setup_args())
+    try:
+        runner.wait_ready()
+
+        publisher.publish_message(
+            exchange_name=exchange,
+            routing_key=routing_key,
+            message=payload,
+            exchange_type="direct",
+            queue_name=queue,
+            auto_declare=False,
+        )
+
+        assert callback_done.wait(timeout=10), "Callback was never invoked"
+        assert received == [payload]
+    finally:
+        runner.stop()
+        publisher.close()
+        consumer.close()
+
+    runner.raise_if_thread_errored()


### PR DESCRIPTION
## Integration test suite for mrsal

### What was added
- `tests/integration/` directory with 6 integration tests gated behind `@pytest.mark.integration`:
  - `test_round_trip.py` — publish → consume against a real broker; also exercises quorum-queue declaration.
  - `test_dlx_retry_cycle.py` — failing callback routes to `<queue>.dlx` with the configured `dlx_routing_key` and correct retry headers.
  - `test_async_dlx.py` — same assertion for the async DLX code path.
  - `test_publisher_confirms.py` — forces a broker NACK via a full reject-publish queue; verifies `NackError` actually surfaces.
  - `test_async_concurrency.py` — `max_concurrent_tasks` actually runs N callbacks in parallel against a real broker.
  - `test_payload_model.py` — callback receives the validated pydantic instance, not raw bytes.
- `tests/integration/docker-compose.yml` — `rabbitmq:3.13-management` on host port `5673` to coexist with a local dev broker on `5672`.
- `tests/integration/conftest.py` — shared `SyncConsumerRunner` / `AsyncConsumerRunner` helpers, broker-reachability AMQP probe, cleanup fixture.
- New `nox -s integration` session in `noxfile.py`; default `tests` session now ignores the integration dir.
- `[tool.pytest.ini_options]` in `pyproject.toml` registering the `integration` marker.
- Version bump `3.8.2 → 3.8.3` (test/dev-infra only, no library code change).

### Why it was necessary
- Mrsal had 72 tests, all mock-based. Mocks verify "Python called Python methods" but cannot validate broker-side behavior — what RabbitMQ actually accepts, routes, and rejects.
- Several recently-fixed bugs (silent message loss on publish without confirms, DLX routing-key ignored at publish time, validated payloads discarded before the callback) would all have been caught by a single round-trip test against a live broker. Without integration tests, future regressions in those paths would also slip through.
- For network-protocol libraries (broker clients, DB drivers), integration tests are the convention — pika, aio-pika, psycopg, redis-py all ship them. Mrsal not having any was unusual for a published broker client.

### How to run
```
docker compose -f tests/integration/docker-compose.yml up -d
poetry run nox -s integration
docker compose -f tests/integration/docker-compose.yml down -v
```
Override the broker target with `MRSAL_IT_HOST` / `MRSAL_IT_PORT` / `MRSAL_IT_USER` / `MRSAL_IT_PASS` / `MRSAL_IT_VHOST`.